### PR TITLE
Add basic KWP2000 support and improve UI styling

### DIFF
--- a/ecu_tool/ecu_transport/elm327.py
+++ b/ecu_tool/ecu_transport/elm327.py
@@ -51,6 +51,17 @@ class ELM327:
         self._write(data_hex)
         return self._read_all()
 
+    # ---- KWP2000 helpers ----
+    def set_header(self, header: str) -> str:
+        """Установить KWP-заголовок (3 байта HEX)."""
+        self._write(f"AT SH {header}")
+        return self._read_all()
+
+    def send_raw(self, data_hex: str) -> str:
+        """Отправить произвольные байты (HEX) без интерпретации."""
+        self._write(data_hex)
+        return self._read_all()
+
     def close(self):
         try:
             self.ser.close()

--- a/ecu_tool/ecu_transport/kwp2000.py
+++ b/ecu_tool/ecu_transport/kwp2000.py
@@ -13,16 +13,48 @@
 
 class KWP2000:
     def __init__(self, transport):
-        self.t = transport  # сюда потом передадим низкоуровневый K-Line
+        self.t = transport  # низкоуровневый транспорт (ELM327 и др.)
+
+    # утилита для преобразования строкового ответа ELM -> bytes
+    @staticmethod
+    def _parse(resp: str) -> bytes:
+        tokens = resp.replace("\r", " ").replace("\n", " ").replace(">", " ").split()
+        out = []
+        for t in tokens:
+            try:
+                if len(t) == 2:
+                    out.append(int(t, 16))
+            except ValueError:
+                continue
+        return bytes(out)
 
     def start_session(self, level: int = 0x81):
-        raise NotImplementedError("KWP2000.start_session: not implemented yet")
+        resp = self.t.send_raw(f"10 {level:02X}")
+        data = self._parse(resp)
+        if not data or data[0] != 0x50:
+            raise RuntimeError(f"StartSession failed: {resp}")
+        return data
 
     def tester_present(self):
-        raise NotImplementedError("KWP2000.tester_present: not implemented yet")
+        resp = self.t.send_raw("3E 00")
+        data = self._parse(resp)
+        if not data or data[0] not in (0x7E, 0xC0):
+            raise RuntimeError(f"TesterPresent failed: {resp}")
+        return data
 
     def read_ecu_id(self):
-        raise NotImplementedError("KWP2000.read_ecu_id: not implemented yet")
+        resp = self.t.send_raw("1A 90")  # локальный идентификатор 0x90 — базовый ID
+        data = self._parse(resp)
+        if not data or data[0] != 0x5A:
+            raise RuntimeError(f"ReadEcuId failed: {resp}")
+        return data[2:]
 
     def read_memory(self, address: int, size: int) -> bytes:
-        raise NotImplementedError("KWP2000.read_memory: not implemented yet")
+        if not (0 < size <= 0xFF):
+            raise ValueError("size must be 1..255")
+        a2, a1, a0 = (address >> 16) & 0xFF, (address >> 8) & 0xFF, address & 0xFF
+        resp = self.t.send_raw(f"23 {a2:02X} {a1:02X} {a0:02X} {size:02X}")
+        data = self._parse(resp)
+        if len(data) < 4 or data[0] != 0x63:
+            raise RuntimeError(f"ReadMemory failed: {resp}")
+        return data[4:]


### PR DESCRIPTION
## Summary
- add raw KWP2000 implementation with session, ECU ID and memory read helpers
- wire real backend, CLI and GUI to use ELM327 adapter
- polish Qt interface with dark theme styling

## Testing
- `python -m py_compile ecu_tool/ecu_transport/elm327.py ecu_tool/ecu_transport/kwp2000.py ecu_tool/firmware/io.py ecu_tool/gui/main_qt.py ecu_tool/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5aa23e8388327b9c57955f3fb5e1e