### PR TITLE
Add README with demo usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# ECU Tool
+
+Инструмент для диагностики и работы с прошивками ЭБУ (электронных блоков управления) автомобилей ВАЗ.
+
+## Установка
+
+1. Установите [Python 3.10+](https://www.python.org/).
+2. Создайте виртуальное окружение и активируйте его:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate      # Windows: .venv\Scripts\activate
+   ```
+3. Установите зависимости (минимальный набор для CLI/GUI):
+   ```bash
+   pip install typer rich pyserial PySide6
+   ```
+
+## Запуск GUI
+
+Запустите графический интерфейс:
+```bash
+python run_ecu.py
+```
+По умолчанию в окне включён флажок **«Демо»**, который использует симулятор вместо реального ЭБУ. Для работы с железом снимите флажок и выберите нужный COM‑порт.
+
+## Запуск из командной строки
+
+CLI вызывается модулем `ecu_tool.main`:
+```bash
+python -m ecu_tool.main [команда] [опции]
+```
+Доступные команды: `ports`, `read-dtc`, `ecu-info`, `read-fw`, `write-fw`, `kwp-ping`.
+
+### Примеры
+
+*Считать DTC в демо‑режиме:*
+```bash
+python -m ecu_tool.main read-dtc --demo
+```
+
+*Считать DTC с реального ЭБУ (например, в порту COM3):*
+```bash
+python -m ecu_tool.main read-dtc COM3
+```
+
+*Считать прошивку в файл (демо):*
+```bash
+python -m ecu_tool.main read-fw logs/dump.bin --demo
+```
+
+*Записать прошивку в симулятор:*
+```bash
+python -m ecu_tool.main write-fw firmware.bin --demo
+```
+
+## Сборка standalone
+
+Для создания исполняемого файла используйте [PyInstaller](https://pyinstaller.org/):
+```bash
+pyinstaller ECU-Tool.spec
+```
+Готовый бинарник появится в каталоге `dist/`.
+


### PR DESCRIPTION
## Summary
- document how to set up and run the ECU Tool in GUI and CLI modes
- explain demo mode versus real hardware operation
- add PyInstaller build steps for producing standalone binary

## Testing
- `python -m py_compile run_ecu.py ecu_tool/main.py`
- `pip install typer rich pyserial` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a5adef18fc8327a1e2b54651c264c7